### PR TITLE
android with luajit(lua5.1)can not encode negative number

### DIFF
--- a/pb.c
+++ b/pb.c
@@ -281,7 +281,7 @@ static uint64_t lpb_tointegerx(lua_State *L, int idx, int *isint) {
 #if LUA_VERSION_NUM >= 503
     uint64_t v = (uint64_t)lua_tointegerx(L, idx, isint);
 #else
-    uint64_t v = (uint64_t)lua_tonumberx(L, idx, isint);
+    uint64_t v = (uint64_t)(int64_t)lua_tonumberx(L, idx, isint);
 #endif
     if (*isint) return v;
     if ((os = s = lua_tostring(L, idx)) == NULL) return 0;


### PR DESCRIPTION
on android cell phone, the code can not get the right value, when the number is -1,

uint64_t v = (uint64_t)lua_tonumberx(L, idx, isint);

but the code can get the right value
uint64_t v = (uint64_t)(int64_t)lua_tonumberx(L, idx, isint);