### PR TITLE
support complex options

### DIFF
--- a/protoc.lua
+++ b/protoc.lua
@@ -217,10 +217,43 @@ function Lexer:quote(opt)
    end
 end
 
+function Lexer:structure(opt)
+   self:whitespace()
+   if not self:test "{" then
+      return self:opterror(opt, 'opening curly brace expected')
+   end
+   local t = {}
+   while not self:test "}" do
+      local ident = self:full_ident "field name"     -- TODO: full_ident?
+      self:test ":"
+      local value = self:constant()
+      self:test ","
+      self:line_end "opt"
+      t[ident] = value
+   end
+   return t
+end
+
+function Lexer:array(opt)
+   self:whitespace()
+   if not self:test "%[" then
+      return self:opterror(opt, 'opening square bracket expected')
+   end
+   local t = {}
+   while not self:test "]" do
+      local value = self:constant()
+      self:test ","
+      t[#t + 1] = value
+   end
+   return t
+end
+
 function Lexer:constant(opt)
    local c = self:full_ident('constant', 'opt') or
              self:number('opt') or
-             self:quote('opt')
+             self:quote('opt') or
+             self:structure('opt') or
+             self:array('opt')
    if not c and not opt then
       return self:error "constant expected"
    end
@@ -562,6 +595,10 @@ function msg_body:oneof(lex, info)
    ot[index] = oneof
 end
 
+function msg_body:option(lex, info)
+   toplevel.option(self, lex, default(info, 'options'))
+end
+
 end
 
 function toplevel:message(lex, info)
@@ -681,6 +718,10 @@ function svr_body:rpc(lex, info)
    lex:line_end "opt"
    local t = default(info, "method")
    insert_tab(t, rpc)
+end
+
+function svr_body:option(lex, info)
+   toplevel.option(self, lex, default(info, 'options'))     -- TODO: should be deeper in the info?
 end
 
 function svr_body.stream(_, lex)


### PR DESCRIPTION
Adds "structure" and "array" as types of constants.  Also allows options within services and messages.  Seems to correctly parse Google's example [a_bit_of_everything.proto](https://github.com/grpc-ecosystem/grpc-gateway/blob/master/examples/proto/examplepb/a_bit_of_everything.proto).

Solves #90 