### PR TITLE
option for MultiLuaVm share read only pb state

### DIFF
--- a/pb.c
+++ b/pb.c
@@ -192,8 +192,8 @@ static lpb_State *default_lstate(lua_State *L) {
         }
         else{
             LS->state = &LS->local;
+            pb_init(&LS->local);
         }
-        pb_init(&LS->local);
         pb_initbuffer(&LS->buffer);
         luaL_setmetatable(L, PB_STATE);
         lua_rawsetp(L, LUA_REGISTRYINDEX, state_name);


### PR DESCRIPTION
共享pbState, 减少多LuaVM情况下内存占用,提高创建速度(只用解析一次pb文件)。
使用方法
1. 首先启动一个luaVM加载 pb文件，然后共享只读pbState。
**这个luaVM生命周期必须长于其它LuaVM**
```lua
    local unsafe = require "pb.unsafe"
    unsafe.share_state()
    local pb = require "pb"
    pb.load(io.readfile("example.pb"))
```
2. 其它LuaVM使用共享pbState
```lua
  local pb = require "pb"
  local data = pb.encode("Person", tb)
  pb.decode("Person", data)
```