### PR TITLE
Fix allow proto3 optional keyword in imported protos.

### DIFF
--- a/protoc.lua
+++ b/protoc.lua
@@ -780,7 +780,7 @@ local function make_context(self, lex)
    ctx.typemap = self.typemap
    ctx.paths   = self.paths
    ctx.proto3_optional =
-      self.experimental_allow_proto3_optional
+      self.proto3_optional or self.experimental_allow_proto3_optional
 
    function ctx.import_fallback(import_name)
       if self.unknown_import == true then


### PR DESCRIPTION
When enabling the experimental proto3 optional keyword config, it was not being propagated through to imported proto files.