### PR TITLE
run encoding hooks before checking types

### DIFF
--- a/pb.c
+++ b/pb.c
@@ -1548,6 +1548,7 @@ static void lpbE_field(lpb_Env *e, const pb_Field *f, size_t *plen) {
         break;
 
     case PB_Tmessage:
+        lpb_useenchooks(L, e->LS, f->type);
         lpb_checktable(L, f);
         len = pb_bufflen(b);
         lpb_encode(e, f->type);
@@ -1618,7 +1619,6 @@ static void lpbE_repeated(lpb_Env *e, const pb_Field *f) {
 static void lpb_encode(lpb_Env *e, const pb_Type *t) {
     lua_State *L = e->L;
     luaL_checkstack(L, 3, "message too many levels");
-    lpb_useenchooks(L, e->LS, t);
     lua_pushnil(L);
     while (lua_next(L, -2)) {
         if (lua_type(L, -2) == LUA_TSTRING) {
@@ -1646,6 +1646,7 @@ static int Lpb_encode(lua_State *L) {
     e.L = L, e.LS = LS, e.b = test_buffer(L, 3);
     if (e.b == NULL) pb_resetbuffer(e.b = &LS->buffer);
     lua_pushvalue(L, 2);
+    lpb_useenchooks(L, e.LS, t);
     lpb_encode(&e, t);
     if (e.b != &LS->buffer)
         lua_settop(L, 3);

--- a/test.lua
+++ b/test.lua
@@ -1258,28 +1258,36 @@ function _G.test_encode_hook()
    local s = {}
    make_encode_hook("Person", function(name, t)
       s[#s+1] = ("(%s|%s)"):format(name, t.name)
+      return t
    end)
-   make_encode_hook("Phone", function(name, t)
+   make_encode_hook("Phone", function(name, ph)
+      ph_name, ty, num = ph:match("(%w+)|(%w+)|(%d+)")
+      t = {
+         name = ph_name,
+         type = ty,
+         phonenumber = tonumber(num),
+      }
       s[#s+1] = ("(%s|%s|%s)"):format(name, t.name, t.phonenumber)
       return t
    end)
-   make_encode_hook("Type", function(name, t)
-      s[#s+1] = ("(%s|(%s)%s)"):format(name, t.type, t.value)
-      return t.value
+   make_encode_hook("Type", function(name, v)
+      local t = v:lower() == v and "HOME" or "WORK"
+      s[#s+1] = ("(%s|(%s)%s)"):format(name, v, t)
+      return t
    end)
    local data = {
       name = "ilse",
       age  = 18,
       contacts = {
-         { name = "alice", type = {type="zzz", value="HOME"}, phonenumber = 12312341234 },
-         { name = "bob",   type = {type="grr", value="WORK"}, phonenumber = 45645674567 }
+         "alice|zzz|12312341234",
+         "bob|Grr|45645674567",
       }
    }
    local res = pb.decode("Person", pb.encode("Person", data))
    s = table.concat(s)
    assert(s == "(Person|ilse)(Phone|alice|12312341234)"..
           "(Type|(zzz)HOME)(Phone|bob|45645674567)"..
-         "(Type|(grr)WORK)")
+         "(Type|(Grr)WORK)")
    end)
 end
 


### PR DESCRIPTION
Normally only tables can be encoded as structures, but encoding hooks
can produce those tables from any data type.

Main usecase: google.protobuf.Timestamp is canonically encoded in JSON
as a datetime string.