### PR TITLE
support encode default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,8 @@ These options are supported currently:
 | `use_default_metatable` | set default values by set table from `pb.default()` as the metatable |
 | `enable_hooks`          | `pb.decode` will call `pb.hooks()` hook functions            |
 | `disable_hooks`         | `pb.decode` do not call hooks **(default)**                  |
+| `encode_default_values` | default values also encode |
+| `decode_default_array`  | decode null to empty table for array |
 
  *Note*: The string returned by `int64_as_string` or `int64_as_hexstring` will prefix a `'#'` character. Because Lua may convert between string with number, prefix a `'#'` makes Lua return the string as-is.
 

--- a/README.md
+++ b/README.md
@@ -332,7 +332,9 @@ These options are supported currently:
 | `enable_hooks`          | `pb.decode` will call `pb.hooks()` hook functions            |
 | `disable_hooks`         | `pb.decode` do not call hooks **(default)**                  |
 | `encode_default_values` | default values also encode |
-| `decode_default_array`  | decode null to empty table for array |
+| `no_encode_default_values` | do not encode default values **(default)** |
+| `decode_default_array`  | work with `no_default_values`,decode null to empty table for array |
+| `no_decode_default_array`  | work with `no_default_values`,decode null to nil for array **(default)** |
 
  *Note*: The string returned by `int64_as_string` or `int64_as_hexstring` will prefix a `'#'` character. Because Lua may convert between string with number, prefix a `'#'` makes Lua return the string as-is.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -366,8 +366,8 @@ end
 | `use_default_metatable` | 将默认值表作为解码目标表的元表使用 |
 | `enable_hooks`          | `pb.decode` 启用钩子功能      |
 | `disable_hooks`         | `pb.decode` 禁用钩子功能 **(默认)**            |
-| `decode_default_values` | 默认值也参与编码 |
-| `disable_hooks`         | 对于数组,将空值解码为空表 |
+| `encode_default_values` | 默认值也参与编码 |
+| `decode_default_array`  | 对于数组,将空值解码为空表 |
 
  *注意*： `int64_as_string` 或 `int64_as_hexstring` 返回的字符串会带一个 `'#'` 字符前缀，因为Lua会自动把数字表示的字符串当作数字使用，从而导致精度损失。带一个前缀会让Lua认为这个字符串并不是数字，从而避免了Lua的自动转换。
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -366,6 +366,8 @@ end
 | `use_default_metatable` | 将默认值表作为解码目标表的元表使用 |
 | `enable_hooks`          | `pb.decode` 启用钩子功能      |
 | `disable_hooks`         | `pb.decode` 禁用钩子功能 **(默认)**            |
+| `decode_default_values` | 默认值也参与编码 |
+| `disable_hooks`         | 对于数组,将空值解码为空表 |
 
  *注意*： `int64_as_string` 或 `int64_as_hexstring` 返回的字符串会带一个 `'#'` 字符前缀，因为Lua会自动把数字表示的字符串当作数字使用，从而导致精度损失。带一个前缀会让Lua认为这个字符串并不是数字，从而避免了Lua的自动转换。
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -367,7 +367,9 @@ end
 | `enable_hooks`          | `pb.decode` 启用钩子功能      |
 | `disable_hooks`         | `pb.decode` 禁用钩子功能 **(默认)**            |
 | `encode_default_values` | 默认值也参与编码 |
-| `decode_default_array`  | 对于数组,将空值解码为空表 |
+| `no_encode_default_values` | 默认值不参与编码 **(默认)** |
+| `decode_default_array`  | 配合`no_default_values`选项,对于数组,将空值解码为空表 |
+| `no_decode_default_array`  | 配合`no_default_values`选项,对于数组,将空值解码为nil **(默认)** |
 
  *注意*： `int64_as_string` 或 `int64_as_hexstring` 返回的字符串会带一个 `'#'` 字符前缀，因为Lua会自动把数字表示的字符串当作数字使用，从而导致精度损失。带一个前缀会让Lua认为这个字符串并不是数字，从而避免了Lua的自动转换。
 

--- a/pb.c
+++ b/pb.c
@@ -1572,9 +1572,8 @@ static void lpbE_tagfield(lpb_Env *e, const pb_Field *f, int ignorezero) {
     size_t ignoredlen;
     lpbE_field(e, f, &ignoredlen);
     lpb_State *LS = e->LS;
-    if (!LS->encode_default_values) {
-        if (ignoredlen != 0 && ignorezero)
-            e->b->size -= (unsigned)(ignoredlen + hlen);
+    if (!LS->encode_default_values && ignoredlen != 0 && ignorezero) {
+        e->b->size -= (unsigned)(ignoredlen + hlen);
     }
 }
 
@@ -1872,7 +1871,9 @@ static int Lpb_option(lua_State *L) {
     X(9, enable_hooks,          LS->use_hooks = 1)                 \
     X(10, disable_hooks,        LS->use_hooks = 0)                 \
     X(11, encode_default_values,LS->encode_default_values = 1)     \
-    X(12, decode_default_array, LS->decode_default_array = 1)      \
+    X(12, no_encode_default_values,LS->encode_default_values = 0)  \
+    X(13, decode_default_array, LS->decode_default_array = 1)      \
+    X(14, no_decode_default_array, LS->decode_default_array = 0)   \
 
     static const char *opts[] = {
 #define X(ID,NAME,CODE) #NAME,

--- a/test.lua
+++ b/test.lua
@@ -461,6 +461,8 @@ function _G.test_default()
    eq(dt.bool2, nil)
    table_eq(dt.array, {})
 
+   pb.option "no_encode_default_values"
+   pb.option "no_decode_default_array"
    pb.option "no_default_values"
 
    pb.option "enum_as_name"

--- a/test.lua
+++ b/test.lua
@@ -450,7 +450,7 @@ function _G.test_default()
       array = {},
    })
    local chunk2, _ = pb.encode("TestDefault", {defaulted_int = 0,defaulted_bool = true})
-   local data2 = pb.decode("TestDefault", chunk2)
+   local dt = pb.decode("TestDefault", chunk2)
    eq(dt.defaulted_int, 0)
    eq(dt.defaulted_bool, true)
    eq(dt.defaulted_str, nil)

--- a/test.lua
+++ b/test.lua
@@ -443,7 +443,8 @@ function _G.test_default()
    table_eq(dt.array, {})
 
    pb.option "no_default_values"
-   pb.option "enable_encode_default_values"
+   pb.option "encode_default_values"
+   pb.option "decode_default_array"
    local dt = pb.decode("TestDefault", "")
    eq(getmetatable(dt), nil)
    table_eq(dt,{
@@ -460,7 +461,6 @@ function _G.test_default()
    eq(dt.bool2, nil)
    table_eq(dt.array, {})
 
-   pb.option "disable_encode_default_values"
    pb.option "no_default_values"
 
    pb.option "enum_as_name"

--- a/test.lua
+++ b/test.lua
@@ -443,6 +443,25 @@ function _G.test_default()
    table_eq(dt.array, {})
 
    pb.option "no_default_values"
+   pb.option "enable_encode_default_values"
+   local dt = pb.decode("TestDefault", "")
+   eq(getmetatable(dt), nil)
+   table_eq(dt,{
+      array = {},
+   })
+   local chunk2, _ = pb.encode("TestDefault", {defaulted_int = 0,defaulted_bool = true})
+   local data2 = pb.decode("TestDefault", chunk2)
+   eq(dt.defaulted_int, 0)
+   eq(dt.defaulted_bool, true)
+   eq(dt.defaulted_str, nil)
+   eq(dt.defaulted_num, nil)
+   eq(dt.color, nil)
+   eq(dt.bool1, nil)
+   eq(dt.bool2, nil)
+   table_eq(dt.array, {})
+
+   pb.option "disable_encode_default_values"
+   pb.option "no_default_values"
 
    pb.option "enum_as_name"
    pb.clear "TestDefault"


### PR DESCRIPTION
use pb.option "enable_encode_default_values" and pb.option "no_default_values" can distinguish 'default value' and 'nil'
see #136