### PR TITLE
fix: don't reset pos on full_ident

### DIFF
--- a/protoc.lua
+++ b/protoc.lua
@@ -227,7 +227,6 @@ function Lexer:structure(opt)
       local pos, name, npos = self "^%s*()(%b[])()"
       if not pos then
          name = self:full_ident "field name"
-         self.pos = pos
       else
          self.pos = npos
       end


### PR DESCRIPTION
local `pos` is nil.  the position is advanced on `self:full_ident()`

Signed-off-by: Javier Guerra <javier@guerrag.com>