### PR TITLE
add pack unpack message api

### DIFF
--- a/pb.c
+++ b/pb.c
@@ -2008,7 +2008,6 @@ static int lpb_unpack_msg(lpb_Env* e, const pb_Type* t) {
         lpb_pushunpackdef(L, e->LS, t, list, top);
     }
 
-    if (e->LS->use_dec_hooks) lpb_usedechooks(L, e->LS, t);
     return field_count;
 }
 

--- a/pb.c
+++ b/pb.c
@@ -1928,7 +1928,7 @@ static int Lpb_decode(lua_State *L) {
 
 void lpb_pushunpackdef(lua_State* L, lpb_State* LS, const pb_Type* t, pb_Field** l, int top) {
     unsigned int i;
-    int mode = LS->default_mode;
+    int mode = LS->encode_mode;
     mode = t->is_proto3 && mode == LPB_DEFDEF ? LPB_COPYDEF : mode;
     if (mode != LPB_COPYDEF && mode != LPB_METADEF) return;
 

--- a/pb.h
+++ b/pb.h
@@ -1255,6 +1255,13 @@ PB_API pb_Type *pb_newtype(pb_State *S, pb_Name *tname) {
     return te->value = t;
 }
 
+PB_API void pb_delsort(pb_Type *t) {
+    if (t->field_sort) {
+        free(t->field_sort);
+        t->field_sort = NULL;
+    }
+}
+
 PB_API void pb_deltype(pb_State *S, pb_Type *t) {
     pb_FieldEntry *nf = NULL;
     pb_OneofEntry *ne = NULL;
@@ -1277,8 +1284,7 @@ PB_API void pb_deltype(pb_State *S, pb_Type *t) {
     pb_freetable(&t->oneof_index);
     t->oneof_field = 0, t->field_count = 0;
     t->is_dead = 1;
-    free(t->field_sort);
-    t->field_sort = NULL;
+    pb_delsort(t);
     /*pb_delname(S, t->name); */
     /*pb_poolfree(&S->typepool, t); */
 }
@@ -1305,6 +1311,7 @@ PB_API pb_Field *pb_newfield(pb_State *S, pb_Type *t, pb_Name *fname, int32_t nu
     if (tf->value && pb_fname(t, tf->value->name) != tf->value)
         pbT_freefield(S, tf->value), --t->field_count;
     ++t->field_count;
+    pb_delsort(t);
     return nf->value = tf->value = f;
 }
 
@@ -1317,6 +1324,7 @@ PB_API void pb_delfield(pb_State *S, pb_Type *t, pb_Field *f) {
     if (nf && nf->value == f) nf->entry.key = 0, nf->value = NULL, ++count;
     if (tf && tf->value == f) tf->entry.key = 0, tf->value = NULL, ++count;
     if (count) pbT_freefield(S, f), --t->field_count;
+    pb_delsort(t);
 }
 
 

--- a/pb.h
+++ b/pb.h
@@ -324,6 +324,7 @@ struct pb_Field {
     pb_Type *type;
     pb_Name *default_value;
     int32_t  number;
+    int32_t  sort_index;
     unsigned oneof_idx : 24;
     unsigned type_id   : 5; /* PB_T* enum */
     unsigned repeated  : 1;
@@ -334,6 +335,7 @@ struct pb_Field {
 struct pb_Type {
     pb_Name    *name;
     const char *basename;
+    pb_Field **field_sort;
     pb_Table field_tags;
     pb_Table field_names;
     pb_Table oneof_index;
@@ -1157,6 +1159,33 @@ PB_API const pb_Field *pb_field(const pb_Type *t, int32_t number) {
     return fe ? fe->value : NULL;
 }
 
+
+static int comp_field(const void* a, const void* b) {
+    return (*(const pb_Field**)a)->number - (*(const pb_Field**)b)->number;
+}
+
+PB_API pb_Field** pb_sortfield(pb_Type* t) {
+    if (!t->field_sort && t->field_count) {
+        int index = 0;
+        unsigned int i = 0;
+        const pb_Field* f = NULL;
+        pb_Field** list = malloc(sizeof(pb_Field*) * t->field_count);
+
+        assert(list);
+        while (pb_nextfield(t, &f)) {
+            list[index++] = (pb_Field*)f;
+        }
+
+        qsort(list, index, sizeof(pb_Field*), comp_field);
+        for (i = 0; i < t->field_count; i++) {
+            list[i]->sort_index = i + 1;
+        }
+        t->field_sort = list;
+    }
+
+    return t->field_sort;
+}
+
 PB_API const pb_Name *pb_oneofname(const pb_Type *t, int idx) {
     pb_OneofEntry *oe = NULL;
     if (t != NULL) oe = (pb_OneofEntry*)pb_gettable(&t->oneof_index, idx);
@@ -1248,6 +1277,8 @@ PB_API void pb_deltype(pb_State *S, pb_Type *t) {
     pb_freetable(&t->oneof_index);
     t->oneof_field = 0, t->field_count = 0;
     t->is_dead = 1;
+    free(t->field_sort);
+    t->field_sort = NULL;
     /*pb_delname(S, t->name); */
     /*pb_poolfree(&S->typepool, t); */
 }

--- a/test.lua
+++ b/test.lua
@@ -1620,10 +1620,42 @@ function _G.test_pack_unpack_msg()
       eq(c1, person.contacts)
       eq(m1, person.map)
       -- eq(f1, person.friends) -- no friend field anymore
-
    end)
 end
 
+function _G.test_extend_pack()
+   local P = protoc.new()
+
+   assert(P:load([[
+      syntax = "proto3";
+      message ExtendPackTest {
+         int32 id = 200;
+         extensions 100 to 199;
+      }
+   ]], "extend_pack_test.proto"))
+
+   local i = 123456789
+   local s = "abcdefghijklmn"
+   local b = pb.pack_msg("ExtendPackTest", i)
+
+   assert(P:load([[
+      syntax = "proto3";
+      import "extend_pack_test.proto"
+
+      extend ExtendPackTest {
+         string ext_name = 100;
+      }
+   ]]))
+   local s1, i1 = pb.unpack_msg("ExtendPackTest", b)
+   eq(s1, "")
+   eq(i1, i)
+
+   local b2 = pb.pack_msg("ExtendPackTest", s, i)
+   pb.clear("ExtendPackTest", "ext_name")
+   local v1, v2 = pb.unpack_msg("ExtendPackTest", b2)
+   eq(v1, i)
+   eq(v2, nil)
+end
 
 if _VERSION == "Lua 5.1" and not _G.jit then
    lu.LuaUnit.run()

--- a/test.lua
+++ b/test.lua
@@ -1538,6 +1538,34 @@ function _G.test_pack_unpack_msg()
    eq(m4, nil)
    eq(f4, nil)
 
+   pb.option "enable_hooks"
+   pb.option "enable_enchooks"
+
+   local hook_contacts = {
+      { name = "alice", phonenumber = 123456789 },
+   }
+   local hook_count = 0
+   pb.encode_hook("Person", function(v)
+      hook_count = hook_count + 1
+      eq(true, false) -- won't be called
+   end)
+   pb.encode_hook("Phone", function(v)
+      hook_count = hook_count + 1
+      eq(v, hook_contacts[1])
+   end)
+   pb.hook("Person", function(v)
+      hook_count = hook_count + 1
+      eq(true, false) -- won't be called
+   end)
+   pb.hook("Phone", function(v)
+      hook_count = hook_count + 1
+      eq(v, hook_contacts[1])
+   end)
+   local b5 = pb.pack_msg("Person", nil, age, nil, hook_contacts)
+   local n5, a5 = pb.unpack_msg("Person", b5)
+
+   eq(hook_count, 2)
+
    end)
 end
 


### PR DESCRIPTION
相关讨论 #203

```lua
local name = "ilise"
local id = 10
local email = "888888888@github.com"
local phone = {1 = {type = "MOBILE",number = "12312341234"},2 = {type = "WORK",number = "45645674567"}}}
local buffer_person = pb.pack_msg("tutorial.Person", name, id, email, phone)
name, id, email, phone = pb.unpack_msg("tutorial.Person", buffer_person)
```

*  使用pack、unpack时hook对根message无法回调，因为不存在一个table
*  相对encode、decode效率大概会提升10%~20%，并且不需要创建根table
* 后续是否考虑改成pb.pack、pb.unpack接口。现有的pack、unpack接口放回buffer和slice模块

一些简单的测试结果  [https://github.com/changnet/protobuf-test](https://github.com/changnet/protobuf-test)