### PR TITLE
add metatable to decoded array and message to tell array from map

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ In below table of functions, we have several types that have special means:
 | `repeated <type>`                                  | `table` with metatable `pb.array_meta`                       |
 | `enum`                                             | `string` or `number`                                         |
 
-`pb.map_meta` and `pb.array_meta` have the field `__pbtype` with value `"map"` and `"array"` respectively.
+`pb.map_meta` and `pb.array_meta` have the field `__type` with value `"map"` and `"array"` respectively.
 
 Note that the metatable may be changed by hook functions, more reliable way to check if an empty table is representing an empty message instead of an array is to test with `getmetatable(v) ~= pb.array_meta`.
 

--- a/README.md
+++ b/README.md
@@ -221,8 +221,13 @@ In below table of functions, we have several types that have special means:
 | `int64`, `uint64`, `fixed64`, `sfixed64`, `sint64` | `number` or `"#"` prefixed `string` or `integer` in Lua 5.3+ |
 | `bool`                                             | `boolean`                                                    |
 | `string`, `bytes`                                  | `string`                                                     |
-| `message`                                          | `table`                                                      |
+| `message`                                          | `table` with metatable `pb.map_meta`                         |
+| `repeated <type>`                                  | `table` with metatable `pb.array_meta`                       |
 | `enum`                                             | `string` or `number`                                         |
+
+`pb.map_meta` and `pb.array_meta` have the field `__pbtype` with value `"map"` and `"array"` respectively.
+
+Note that the metatable may be changed by hook functions, more reliable way to check if an empty table is representing an empty message instead of an array is to test with `getmetatable(v) ~= pb.array_meta`.
 
 #### Type Information
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -244,8 +244,13 @@ end
 | `int64`, `uint64`, `fixed64`, `sfixed64`, `sint64` | `number` 或 `"#"` 打头的 `string` 或 `integer` （Lua 5.3+） |
 | `bool`                                             | `boolean`                                                  |
 | `string`, `bytes`                                  | `string`                                                   |
-| `message`                                          | `table`                                                    |
+| `message`                                          | `table`, 其 metatable 为 `pb.map_meta`                     |
+| `repeated <type>`                                  | `table`, 其 metatable 为 `pb.array_meta`                   |
 | `enum`                                             | `string` 或 `number`                                       |
+
+`pb.map_meta` 与 `pb.array_meta` 都有成员 `__pbtype`，其值分别为 `"map"`、 `"array"`.
+
+注意，由于钩子函数可能修改 metatable，检查一个空表是否是空的 message 较为可靠的方式是 `getmetatable(v) ~= pb.array_meta`.
 
 #### 内存数据库信息获取
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -248,7 +248,7 @@ end
 | `repeated <type>`                                  | `table`, 其 metatable 为 `pb.array_meta`                   |
 | `enum`                                             | `string` 或 `number`                                       |
 
-`pb.map_meta` 与 `pb.array_meta` 都有成员 `__pbtype`，其值分别为 `"map"`、 `"array"`.
+`pb.map_meta` 与 `pb.array_meta` 都有成员 `__type`，其值分别为 `"map"`、 `"array"`.
 
 注意，由于钩子函数可能修改 metatable，检查一个空表是否是空的 message 较为可靠的方式是 `getmetatable(v) ~= pb.array_meta`.
 

--- a/pb.c
+++ b/pb.c
@@ -2127,11 +2127,11 @@ LUALIB_API int luaopen_pb(lua_State *L) {
     }
     if (luaL_newmetatable(L, PB_MAP)) {
         lua_pushstring(L, "map");
-        lua_setfield(L, -2, "__pbtype");
+        lua_setfield(L, -2, "__type");
     }
     if (luaL_newmetatable(L, PB_ARRAY)) {
         lua_pushstring(L, "array");
-        lua_setfield(L, -2, "__pbtype");
+        lua_setfield(L, -2, "__type");
     }
     luaL_newlib(L, libs);
     luaL_getmetatable(L, PB_ARRAY);

--- a/test.lua
+++ b/test.lua
@@ -657,14 +657,14 @@ end
 function _G.test_map()
    check_load [[
    syntax = "proto3";
-   message TestEmpty {}
+   message TestMapArray {}
    message TestNum {
       int32 f = 1;
    }
    message TestMap {
        map<string, int32> map = 1;
        map<string, int32> packed_map = 2 [packed=true];
-       map<string, TestEmpty> msg_map = 3;
+       map<string, TestMapArray> msg_map = 3;
    } ]]
 
    check_msg("TestMap", { map = {}, packed_map = {}, msg_map = {} })
@@ -1683,6 +1683,35 @@ function _G.test_extend_pack()
    local v1, v2 = pb.unpack("ExtendPackTest", b2)
    eq(v1, i)
    eq(v2, nil)
+end
+
+function _G.test_map_array_decode()
+   check_load [[
+   syntax = "proto3";
+   message MAP {
+      optional uint32 id = 1;
+   }
+   message TestMapArray {
+      MAP map = 1;
+      repeat MAP array = 2;
+   } ]]
+
+   local simple = { {}, {} }
+   local complex = { map = { id = 1 }, array = { { id = 1 }, {} } }
+   
+   local chunk = pb.encode("TestMapArray", simple)
+   local data = pb.decode("TestMapArray", chunk)
+   is_true(getmetatable(data.map) == pb.map_meta)
+   is_true(getmetatable(data.array) == pb.array_meta)
+   eq(data, simple)
+
+   chunk = pb.encode("TestMapArray", complex)
+   data = pb.decode("TestMapArray", chunk)
+   is_true(getmetatable(data.map) == pb.map_meta)
+   is_true(getmetatable(data.array) == pb.array_meta)
+   eq(data, complex)
+   
+   pb.clear "TestOneof"
 end
 
 if _VERSION == "Lua 5.1" and not _G.jit then


### PR DESCRIPTION
We cannot tell empty lua tables from arrays. This PR introduce metatable for them to solve the issue.