### PR TITLE
add metatable to decoded array and message to tell array from map

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,12 @@ In below table of functions, we have several types that have special means:
 | `bool`                                             | `boolean`                                                    |
 | `string`, `bytes`                                  | `string`                                                     |
 | `message`                                          | `table`                                                      |
+| `repeated <type>`                                  | `table` with metatable `pb.array_meta`                       |
 | `enum`                                             | `string` or `number`                                         |
+
+When used with OpenResty's branch of [lua-cjson](https://github.com/openresty/lua-cjson), `pb.array_meta` will be the same table to the `cjson`'s `empty_array_mt`.
+
+To check if an empty table is an array, you can test with `getmetatable(tbl) == pb.array_meta`.
 
 #### Type Information
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -245,7 +245,12 @@ end
 | `bool`                                             | `boolean`                                                  |
 | `string`, `bytes`                                  | `string`                                                   |
 | `message`                                          | `table`                                                    |
+| `repeated <type>`                                  | `table`, 其元表为 `pb.array_meta`                           |
 | `enum`                                             | `string` 或 `number`                                       |
+
+当与 OpenResty 的 [lua-cjson](https://github.com/openresty/lua-cjson) 分支一起使用, `pb.array_meta` 与 `lua-cjson` 的 `empty_array_mt` 为同一个 Lua 表.
+
+要检查一个空表是否是数组，可以这样判断： `getmetatable(tbl) == pb.array_meta`.
 
 #### 内存数据库信息获取
 


### PR DESCRIPTION
We cannot tell empty Lua tables from arrays. This PR introduces metatable for them to solve the issue.
This is an alternative solution to #240.
We make use of `OpenResty/lua-cjson`'s `empty_array_mt`.