### PR TITLE
fix unknown type when using relative namespace in proto

### DIFF
--- a/protoc.lua
+++ b/protoc.lua
@@ -965,7 +965,10 @@ local function check_service(self, lex, info)
 end
 
 function Parser:resolve(lex, info)
-   self.prefix = { "", info.package }
+   self.prefix = { "" }
+   for token in string.gmatch(info.package, "[^.]+") do
+      insert_tab(self.prefix, token)
+   end
    for _, v in iter(info, 'message_type') do
       check_message(self, lex, v)
    end


### PR DESCRIPTION
修复引用外部type不使用全名时会导致unknown type的问题

```protobuf
// a.proto
syntax = "proto3";

package com.x.a;

message A {
  int32 n = 1;
}

// b.proto
syntax = "proto3";

package com.x.b;

message B {
 a.A a = 1;
}
```

