### PR TITLE
Disallow ignorezero in Message field

### DIFF
--- a/pb.c
+++ b/pb.c
@@ -1728,7 +1728,7 @@ static void lpb_encode_onefield(lpb_Env *e, const pb_Type *t, const pb_Field *f,
     else if (f->repeated)
         lpbE_repeated(e, f, idx);
     else if (!f->type || !f->type->is_dead)
-        lpbE_tagfield(e, f, t->is_proto3 && !f->oneof_idx, idx);
+        lpbE_tagfield(e, f, t->is_proto3 && !f->oneof_idx && f->type_id != PB_Tmessage, idx);
 }
 
 static void lpbE_encode(lpb_Env *e, const pb_Type *t, int idx) {


### PR DESCRIPTION
According to [Application note: Field presence](https://github.com/protocolbuffers/protobuf/blob/main/docs/field_presence.md), a Singular Message field without **_optional_** adjective should also have **Explicit Presence**. Ignoring zero-length message field causes indistinguishable presence.