### PR TITLE
fix(lpb_tointegerx): filter out illegal formats, such as, #a, #-aaa...

### DIFF
--- a/pb.c
+++ b/pb.c
@@ -340,7 +340,7 @@ static uint64_t lpb_tointegerx(lua_State *L, int idx, int *isint) {
     } else {
         for (; *s != '\0'; ++s) {
             int n = lpb_hexchar(*s);
-            if (n < 0 || n > 10) break;
+            if (n < 0 || n > 9) break;
             v = v * 10 + n;
         }
     }


### PR DESCRIPTION
```lua
local pb = require "pb"
local protoc = require "protoc"

assert(protoc:load [[
syntax = "proto3";
message Money {
  string currency = 1;
  repeated int64 values = 2;
}]])

local data = {
    currency = "MYR",
    values = {
	-- cases supported
	1, 2, -3, "#123", "0xabF", "#-0x123abcdef", "-#0x123abcdef", "#0x123abc", "123",
	-- cases filtered out
	--- "a", "+aaa", "#aaaaa",
    },
}

--pb.option "int64_as_string"
--pb.option "int64_as_hexstring"

local bytes = assert(pb.encode("Money", data))
print(pb.tohex(bytes))
print(ngx.encode_base64(bytes))

local data2 = assert(pb.decode("Money", bytes))
print(require "serpent".block(data2))

```