### PR TITLE
expose pb.Buffer's internal C string pointer via a new method to mini…

### DIFF
--- a/pb.c
+++ b/pb.c
@@ -839,6 +839,13 @@ static int Lbuf_pack(lua_State *L) {
     return 1;
 }
 
+static int Lbuf_ptr(lua_State *L) {
+    pb_Buffer *buf = check_buffer(L, 1);
+    lua_pushlightuserdata(L, buf->buff);
+    lua_pushinteger(L, buf->size);
+    return 2;
+}
+
 LUALIB_API int luaopen_pb_buffer(lua_State *L) {
     luaL_Reg libs[] = {
         { "__tostring", Lbuf_tostring },
@@ -852,6 +859,7 @@ LUALIB_API int luaopen_pb_buffer(lua_State *L) {
         ENTRY(new),
         ENTRY(reset),
         ENTRY(pack),
+        ENTRY(ptr),
 #undef  ENTRY
         { NULL, NULL }
     };


### PR DESCRIPTION
为 pb.Buffer 添加 ptr() 方法，返回内部缓冲区的指针和数据长度。
buffer:result() 产生的临时 Lua 字符串分配，直接通过 ffi.copy 将数据拷贝到预分配
的发送缓冲区，减少 GC 压力，提升性能。
